### PR TITLE
Added testing platform on py.test + Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: py.test

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import web
+import os
+import pytest
+
+@pytest.fixture
+def app():
+    os.environ["ACCESS_TOKEN"] = "1"
+    return web.app

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests
 # Testing
 # ----------------------
 mock
+pytest-flask
 
 # ----------------------
 # Production Server

--- a/tests/test_challange.py
+++ b/tests/test_challange.py
@@ -1,0 +1,12 @@
+import pytest
+import unittest
+from flask import url_for
+
+@pytest.mark.usefixtures('client_class')
+class ChallengeTestSuite(unittest.TestCase):
+
+    def test_fail_verify(self):
+        assert self.client.get(url_for('webhook')).status_code == 400
+
+    def test_verify(self):
+        assert self.client.get(url_for('webhook')+'?hub.verify_token=challenge_me&hub.challenge=123').status_code == 200

--- a/web.py
+++ b/web.py
@@ -2,52 +2,58 @@
 
 import os
 from flask import Flask, request
+from flask.views import MethodView
 from facebook.api import FacebookApi
 from prayer import PrayerWebhook as webhook
 from raygun4py.middleware import flask
 
 app = Flask(__name__)
-api = FacebookApi()
 flask.Provider(app, os.environ.get('RAYGUN_APIKEY')).attach()
 
 ###
 # Routing for your application.
 ###
 
-def setup():
-    api.post("/me/subscribed_apps")
+class WebhookAPI(MethodView):
 
-@app.route('/webhook')
-def challenge_webhook():
-    """Facebook's API webhook challenge."""
-    if request.args.get('hub.verify_token') == 'challenge_me':
-        challenge = request.args.get('hub.challenge')
-        if challenge:
-            return challenge
+    @property
+    def api():
+        if not hasattr(self, '_api'):
+            self._api = FacebookApi()
+        return self._api
+
+    def get(self, user_id=None):
+        """Facebook's API webhook challenge."""
+        
+        if request.args.get('hub.verify_token') == 'challenge_me':
+            challenge = request.args.get('hub.challenge')
+            if challenge:
+                return challenge
+            else:
+                return "Challenge not found", 400
         else:
-            return "Challenge not found", 400
-    else:
-        return "Wrong validation token", 400
+            return "Wrong validation token", 400
 
-@app.route('/webhook', methods=['POST'])
-def handle_webhook():
-    """Facebook's API webhook."""
-    print("Webhook request data: " + request.data)
-    data = request.get_json()
-    entry = data['entry'][0]
-    messaging_events = entry['messaging']
-    for event in messaging_events:
-        if 'message' in event:
-            response_body = webhook.handle_message(event['sender'], event['message'])
-            if response_body:
-                api.post("/me/messages", response_body)
-        elif 'postback' in event:
-            response_callbacks = webhook.handle_postback(event['sender'], event['postback'])
-            for response_callback in response_callbacks:
-                api.post("/me/messages", response_callback)
-    return "OK"
+    def post(self):
+        """Facebook's API webhook."""
+        print("Webhook request data: " + request.data)
+        data = request.get_json()
+        entry = data['entry'][0]
+        messaging_events = entry['messaging']
+        for event in messaging_events:
+            if 'message' in event:
+                response_body = webhook.handle_message(event['sender'], event['message'])
+                if response_body:
+                    self.api.post("/me/messages", response_body)
+            elif 'postback' in event:
+                response_callbacks = webhook.handle_postback(event['sender'], event['postback'])
+                for response_callback in response_callbacks:
+                    self.api.post("/me/messages", response_callback)
+        return "OK"
 
-setup()
+
+app.add_url_rule('/webhook', view_func=WebhookAPI.as_view('webhook'))
+
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
This pull request do:

* Move into class based views
* Encapsulate FacebookApi into property in WebhookAPI
* setup testing platform on py.test with 2 simple tests for challenge webhook
* add .travis.yml for having continous integration for tests

Tests passed:
https://travis-ci.org/galuszkak/prayerbot/builds/135221663

To start tests you need only after instaling new deps to `py.test` .

Please review @kubaodias 